### PR TITLE
공지 버그 수정

### DIFF
--- a/Server/lib/Web/public/css/style.css
+++ b/Server/lib/Web/public/css/style.css
@@ -153,6 +153,12 @@ span{
 	background-color: #EEBB33;
 	cursor: pointer;
 	z-index: 5;
+	height: 20px;
+}
+#gn-content{
+	position: absolute;
+	left: 0;
+	right: 0;
 }
 .searching{
 	color: #EEEEEE;


### PR DESCRIPTION
메뉴 항목에 마우스를 얹으면 공지사항의 내용이 옆으로 밀리는 버그를 수정하였습니다.
(ehxhfl7님의 PR입니다.)